### PR TITLE
Fix loan-application documents and add employer-document viewing

### DIFF
--- a/src/components/salary-checkoff/EmployerDocuments.tsx
+++ b/src/components/salary-checkoff/EmployerDocuments.tsx
@@ -1,0 +1,283 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from '@/components/salary-checkoff/ui/Button';
+import { Modal } from '@/components/salary-checkoff/ui/Modal';
+import {
+  documentService,
+  Document,
+  isImageDocument,
+  isPdfDocument,
+  isViewableDocument,
+} from '@/services/salary-checkoff/document.service';
+import {
+  FileText,
+  Image,
+  Download,
+  Eye,
+  Loader2,
+  AlertCircle,
+  FolderOpen,
+} from 'lucide-react';
+
+const DOCUMENT_TYPE_LABELS: Record<string, string> = {
+  check_off_agreement: 'Check-off Agreement',
+  remittance_proof: 'Remittance Proof',
+  disbursement_receipt: 'Disbursement Receipt',
+  other: 'Other Document',
+};
+
+function getDocumentTypeLabel(type: string): string {
+  return DOCUMENT_TYPE_LABELS[type] || type.replace(/_/g, ' ').toUpperCase();
+}
+
+interface EmployerDocumentsProps {
+  /** Employer whose documents to show. */
+  employerId: string;
+}
+
+/**
+ * Lists and previews an employer's documents (e.g. check-off agreements).
+ *
+ * Access is enforced by the backend: admins can view any employer's documents,
+ * HR managers only their own employer's. This component simply renders whatever
+ * the API returns for the given employerId.
+ */
+export function EmployerDocuments({ employerId }: EmployerDocumentsProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [downloadingDoc, setDownloadingDoc] = useState<string | null>(null);
+  const [previewDocument, setPreviewDocument] = useState<Document | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const docs = await documentService.listEmployerDocuments(employerId);
+        if (active) setDocuments(Array.isArray(docs) ? docs : []);
+      } catch (err: any) {
+        if (active) setError(err.message || 'Failed to load documents');
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, [employerId]);
+
+  const handleDownload = async (docId: string, filename: string) => {
+    try {
+      setDownloadingDoc(docId);
+      const blob = await documentService.downloadDocument(docId);
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (err: any) {
+      setError('Failed to download document');
+      setTimeout(() => setError(null), 3000);
+    } finally {
+      setDownloadingDoc(null);
+    }
+  };
+
+  const handlePreview = async (doc: Document) => {
+    if (!isViewableDocument(doc)) {
+      handleDownload(doc.id, doc.original_filename);
+      return;
+    }
+
+    setPreviewDocument(doc);
+    setPreviewError(null);
+    setPreviewLoading(true);
+    setPreviewUrl(null);
+
+    try {
+      const objectUrl = await documentService.getDocumentObjectUrl(doc.id);
+      setPreviewUrl(objectUrl);
+    } catch (err) {
+      console.error('Error loading document preview:', err);
+      setPreviewError('Unable to load preview. Try downloading the file instead.');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleClosePreview = () => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setPreviewUrl(null);
+    setPreviewDocument(null);
+    setPreviewError(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-40">
+        <Loader2 className="h-8 w-8 animate-spin text-[#008080]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          <AlertCircle className="h-5 w-5 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {documents.length === 0 && !error && (
+        <div className="text-center py-12">
+          <FolderOpen className="h-12 w-12 text-slate-300 mx-auto mb-3" />
+          <p className="text-slate-600 font-medium">No documents for this employer</p>
+          <p className="text-slate-500 text-sm mt-1">
+            Documents uploaded for this employer will appear here.
+          </p>
+        </div>
+      )}
+
+      {documents.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {documents.map((doc) => {
+            const isImage = isImageDocument(doc);
+            const canPreview = isViewableDocument(doc);
+
+            return (
+              <div
+                key={doc.id}
+                className="border border-slate-200 rounded-lg p-4 flex flex-col hover:bg-slate-50 transition-colors"
+              >
+                <div className="flex items-start gap-3 mb-3">
+                  <div className="h-9 w-9 bg-slate-100 rounded-full flex items-center justify-center flex-shrink-0">
+                    {isImage ? (
+                      <Image className="h-5 w-5 text-blue-500" />
+                    ) : (
+                      <FileText className="h-5 w-5 text-slate-500" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-slate-900 leading-snug">
+                      {getDocumentTypeLabel(doc.document_type)}
+                    </p>
+                    <p className="text-xs text-slate-500 truncate mt-0.5">
+                      {doc.original_filename}
+                    </p>
+                    {doc.file_size > 0 && (
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        {(doc.file_size / 1024).toFixed(1)} KB
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 mt-auto">
+                  {canPreview && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handlePreview(doc)}
+                      leftIcon={<Eye className="h-3.5 w-3.5" />}
+                    >
+                      View
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleDownload(doc.id, doc.original_filename)}
+                    disabled={downloadingDoc === doc.id}
+                    leftIcon={
+                      downloadingDoc === doc.id ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Download className="h-3.5 w-3.5" />
+                      )
+                    }
+                  >
+                    {downloadingDoc === doc.id ? 'Downloading...' : 'Download'}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Document Preview Modal */}
+      <Modal
+        isOpen={previewDocument !== null}
+        onClose={handleClosePreview}
+        title={
+          previewDocument
+            ? getDocumentTypeLabel(previewDocument.document_type)
+            : 'Document Preview'
+        }
+        size="xl"
+      >
+        {previewDocument && (
+          <div className="space-y-4">
+            {previewLoading ? (
+              <div className="flex items-center justify-center h-[60vh]">
+                <Loader2 className="h-8 w-8 animate-spin text-[#008080]" />
+              </div>
+            ) : previewError ? (
+              <div className="text-center py-8">
+                <AlertCircle className="h-12 w-12 text-amber-500 mx-auto mb-3" />
+                <p className="text-slate-600">{previewError}</p>
+              </div>
+            ) : previewUrl && isImageDocument(previewDocument) ? (
+              <div className="flex justify-center">
+                <img
+                  src={previewUrl}
+                  alt={previewDocument.original_filename}
+                  className="max-w-full max-h-[60vh] object-contain rounded-lg border border-slate-200"
+                />
+              </div>
+            ) : previewUrl && isPdfDocument(previewDocument) ? (
+              <div className="w-full h-[60vh]">
+                <iframe
+                  src={previewUrl}
+                  className="w-full h-full rounded-lg border border-slate-200"
+                  title={previewDocument.original_filename}
+                />
+              </div>
+            ) : (
+              <div className="text-center py-8">
+                <FileText className="h-12 w-12 text-slate-400 mx-auto mb-3" />
+                <p className="text-slate-600">Preview not available for this file type</p>
+              </div>
+            )}
+            <div className="flex justify-between items-center pt-4 border-t border-slate-200">
+              <p className="text-sm text-slate-500">{previewDocument.original_filename}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  handleDownload(previewDocument.id, previewDocument.original_filename)
+                }
+                leftIcon={<Download className="h-4 w-4" />}
+              >
+                Download
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/salary-checkoff/layout/Sidebar.tsx
+++ b/src/components/salary-checkoff/layout/Sidebar.tsx
@@ -107,6 +107,11 @@ export function Sidebar({
     icon: DollarSign
   },
   {
+    id: 'company-documents',
+    label: 'Company Documents',
+    icon: FolderOpen
+  },
+  {
     id: 'company-management-organizations',
     label: 'Organizations',
     icon: Building2

--- a/src/pages/salary-checkoff/SalaryCheckOffApp.tsx
+++ b/src/pages/salary-checkoff/SalaryCheckOffApp.tsx
@@ -13,6 +13,7 @@ import { HRDashboard } from './hr/HRDashboard';
 import { ApplicationReview } from './hr/ApplicationReview';
 import { HRActiveLoans } from './hr/HRActiveLoans';
 import { PayrollDeductions } from './hr/PayrollDeductions';
+import { CompanyDocuments } from './hr/CompanyDocuments';
 import { PendingApplications } from './hr/PendingApplications';
 import { AdminDashboard } from './admin/AdminDashboard';
 import { AdminLoanQueue } from './admin/AdminLoanQueue';
@@ -47,6 +48,7 @@ type Page =
   | 'application-review'
   | 'active-loans'
   | 'payroll'
+  | 'company-documents'
   | 'applications'
   | 'loan-queue'
   | 'employers'
@@ -237,6 +239,8 @@ export function SalaryCheckOffApp() {
             return <HRActiveLoans onNavigate={handleNavigate} />;
           case 'payroll':
             return <PayrollDeductions />;
+          case 'company-documents':
+            return <CompanyDocuments />;
           case 'disbursements':
             return <DisbursementHistory onBack={() => handleNavigate('dashboard')} role="hr" />;
           case 'company-management-organizations':

--- a/src/pages/salary-checkoff/admin/Employers.tsx
+++ b/src/pages/salary-checkoff/admin/Employers.tsx
@@ -11,7 +11,8 @@ import {
   InterestMethod,
 } from '@/services/salary-checkoff/employer.service';
 import { formatDate } from '@/utils/formatters';
-import { Loader2, AlertCircle, X, Building2, Search, Settings, Check } from 'lucide-react';
+import { EmployerDocuments } from '@/components/salary-checkoff/EmployerDocuments';
+import { Loader2, AlertCircle, X, Building2, Search, Settings, Check, FileText } from 'lucide-react';
 
 interface EmployersProps {
   onNavigate: (page: string) => void;
@@ -31,6 +32,9 @@ export function Employers({ onNavigate }: EmployersProps) {
   const [isSavingSettings, setIsSavingSettings] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsSuccess, setSettingsSuccess] = useState<string | null>(null);
+
+  // Documents modal state
+  const [documentsEmployer, setDocumentsEmployer] = useState<Employer | null>(null);
 
   useEffect(() => {
     loadEmployers();
@@ -188,6 +192,19 @@ export function Employers({ onNavigate }: EmployersProps) {
       accessor: (item: Employer) => formatDate(item.onboarded_at),
     },
     {
+      header: 'Documents',
+      accessor: (item: Employer) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setDocumentsEmployer(item)}
+          leftIcon={<FileText className="h-4 w-4" />}
+        >
+          View
+        </Button>
+      ),
+    },
+    {
       header: 'Settings',
       accessor: (item: Employer) => (
         <Button
@@ -277,6 +294,18 @@ export function Employers({ onNavigate }: EmployersProps) {
           />
         )}
       </Card>
+
+      {/* Documents Modal */}
+      <Modal
+        isOpen={documentsEmployer !== null}
+        onClose={() => setDocumentsEmployer(null)}
+        title={`Documents: ${documentsEmployer?.name || ''}`}
+        size="xl"
+      >
+        {documentsEmployer && (
+          <EmployerDocuments employerId={documentsEmployer.id} />
+        )}
+      </Modal>
 
       {/* Settings Modal */}
       <Modal

--- a/src/pages/salary-checkoff/employee/LoanApplication.tsx
+++ b/src/pages/salary-checkoff/employee/LoanApplication.tsx
@@ -9,7 +9,6 @@ import { FileUpload } from '@/components/salary-checkoff/ui/FileUpload';
 import { TermsModal } from './TermsModal';
 import { Modal } from '@/components/salary-checkoff/ui/Modal';
 import { loanService, LoanCalculatorResponse } from '@/services/salary-checkoff/loan.service';
-import { documentService, Document } from '@/services/salary-checkoff/document.service';
 import { authService } from '@/services/salary-checkoff/auth.service';
 import { hrNotificationService } from '@/services/salary-checkoff/hrNotification.service';
 import { employerService, loanCalculationUtils, InterestMethod } from '@/services/salary-checkoff/employer.service';
@@ -62,17 +61,16 @@ export function LoanApplication({
   const [bankBranch, setBankBranch] = useState<string>('');
   const [accountNumber, setAccountNumber] = useState<string>('');
 
-  // Document upload state
-  const [uploadedDocuments, setUploadedDocuments] = useState<{
-    nationalIdFront?: Document;
-    nationalIdBack?: Document;
-    payslips?: Document[];
-  }>({});
-  const [uploadingDocs, setUploadingDocs] = useState<{
-    nationalIdFront?: boolean;
-    nationalIdBack?: boolean;
-    payslips?: boolean;
-  }>({});
+  // Document upload state.
+  //
+  // Required documents are submitted together with the loan application in a
+  // single request (the backend creates the application and its documents
+  // atomically). We hold the selected files here until the form is submitted.
+  const [pendingFiles, setPendingFiles] = useState<{
+    nationalIdFront?: File;
+    nationalIdBack?: File;
+    payslips: File[];
+  }>({ payslips: [] });
 
   const calculateLoan = useCallback(async () => {
     const amountNum = parseFloat(amount.replace(/,/g, ''));
@@ -196,11 +194,12 @@ export function LoanApplication({
       setError(null);
     }
 
-    // Step 2: Check if still uploading documents
+    // Step 2: documents are mandatory and are submitted together with the
+    // application. Require them before the user can proceed — an application
+    // cannot go through without its supporting documents.
     if (step === 2) {
-      const isUploading = Object.values(uploadingDocs).some(status => status);
-      if (isUploading) {
-        setError('Please wait for document uploads to complete');
+      if (!pendingFiles.nationalIdFront || !pendingFiles.nationalIdBack || pendingFiles.payslips.length === 0) {
+        setError('Please attach your National ID (front and back) and at least one payslip before continuing.');
         return;
       }
 
@@ -234,7 +233,14 @@ export function LoanApplication({
           applicationData.bank_account_number = accountNumber;
         }
 
-        const createdApplication = await loanService.createApplication(applicationData);
+        // Submit the application together with its required documents. The
+        // backend creates both atomically: if any document fails, the
+        // application is not created, so it never goes through without them.
+        const createdApplication = await loanService.createApplication(applicationData, {
+          national_id_front: pendingFiles.nationalIdFront,
+          national_id_back: pendingFiles.nationalIdBack,
+          payslips: pendingFiles.payslips,
+        });
 
         // Send notification to HR about new application pending approval
         if (employeeProfile?.employee_profile?.employer?.id) {
@@ -280,39 +286,17 @@ export function LoanApplication({
     setStep(3);
   };
 
-  const handleDocumentUpload = async (files: File[], documentType: 'nationalIdFront' | 'nationalIdBack' | 'payslips') => {
-    if (files.length === 0) return;
-
-    try {
-      setUploadingDocs(prev => ({ ...prev, [documentType]: true }));
-      setError(null);
-
-      if (documentType === 'payslips') {
-        // Upload multiple payslips
-        const uploadPromises = files.slice(0, 3).map((file, index) =>
-          documentService.uploadDocument({
-            file,
-            document_type: `payslip_${index + 1}` as any,
-          })
-        );
-        const uploadedPayslips = await Promise.all(uploadPromises);
-        setUploadedDocuments(prev => ({ ...prev, payslips: uploadedPayslips }));
-      } else {
-        // Upload single document
-        const apiDocType = documentType === 'nationalIdFront' ? 'national_id_front' : 'national_id_back';
-        const uploadedDoc = await documentService.uploadDocument({
-          file: files[0],
-          document_type: apiDocType,
-        });
-        setUploadedDocuments(prev => ({ ...prev, [documentType]: uploadedDoc }));
-      }
-    } catch (err: any) {
-      console.error('Error uploading document:', err);
-      setError(err.message || `Failed to upload ${documentType}. Please try again.`);
-    } finally {
-      setUploadingDocs(prev => ({ ...prev, [documentType]: false }));
+  // Stash selected files in state. The actual upload happens at submit time,
+  // once the application exists and we have an application_id to link to.
+  const handleDocumentSelect = (files: File[], documentType: 'nationalIdFront' | 'nationalIdBack' | 'payslips') => {
+    setError(null);
+    if (documentType === 'payslips') {
+      setPendingFiles(prev => ({ ...prev, payslips: files.slice(0, 3) }));
+    } else {
+      setPendingFiles(prev => ({ ...prev, [documentType]: files[0] }));
     }
   };
+
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
@@ -461,43 +445,34 @@ export function LoanApplication({
                 <div className="space-y-4">
                   <FileUpload
                     label="National ID (Front)"
-                    onFilesSelected={(files) => handleDocumentUpload(files, 'nationalIdFront')}
+                    onFilesSelected={(files) => handleDocumentSelect(files, 'nationalIdFront')}
                     helperText={
-                      uploadedDocuments.nationalIdFront
-                        ? `✓ Uploaded: ${uploadedDocuments.nationalIdFront.original_filename}`
-                        : uploadingDocs.nationalIdFront
-                        ? "Uploading..."
+                      pendingFiles.nationalIdFront
+                        ? `✓ Selected: ${pendingFiles.nationalIdFront.name}`
                         : "Clear photo or scan of your ID front side"
                     }
-                    isLoading={uploadingDocs.nationalIdFront}
                   />
 
                   <FileUpload
                     label="National ID (Back)"
-                    onFilesSelected={(files) => handleDocumentUpload(files, 'nationalIdBack')}
+                    onFilesSelected={(files) => handleDocumentSelect(files, 'nationalIdBack')}
                     helperText={
-                      uploadedDocuments.nationalIdBack
-                        ? `✓ Uploaded: ${uploadedDocuments.nationalIdBack.original_filename}`
-                        : uploadingDocs.nationalIdBack
-                        ? "Uploading..."
+                      pendingFiles.nationalIdBack
+                        ? `✓ Selected: ${pendingFiles.nationalIdBack.name}`
                         : "Clear photo or scan of your ID back side"
                     }
-                    isLoading={uploadingDocs.nationalIdBack}
                   />
 
                   <FileUpload
                     label="Latest 3 Payslips"
-                    onFilesSelected={(files) => handleDocumentUpload(files, 'payslips')}
+                    onFilesSelected={(files) => handleDocumentSelect(files, 'payslips')}
                     helperText={
-                      uploadedDocuments.payslips && uploadedDocuments.payslips.length > 0
-                        ? `✓ Uploaded ${uploadedDocuments.payslips.length} payslip(s)`
-                        : uploadingDocs.payslips
-                        ? "Uploading..."
+                      pendingFiles.payslips.length > 0
+                        ? `✓ Selected ${pendingFiles.payslips.length} payslip(s)`
                         : "Upload your most recent payslips (PDF preferred)"
                     }
                     accept=".pdf"
                     multiple
-                    isLoading={uploadingDocs.payslips}
                   />
 
                 </div>

--- a/src/pages/salary-checkoff/hr/CompanyDocuments.tsx
+++ b/src/pages/salary-checkoff/hr/CompanyDocuments.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from '@/components/salary-checkoff/ui/Card';
+import { EmployerDocuments } from '@/components/salary-checkoff/EmployerDocuments';
+import { authService } from '@/services/salary-checkoff/auth.service';
+import { Loader2, AlertCircle, FileText } from 'lucide-react';
+
+/**
+ * HR view of their own company's documents (e.g. check-off agreements).
+ *
+ * Resolves the HR's employer from their profile (hr_profile.employer.id) and
+ * renders the shared EmployerDocuments list. The backend scopes access so an
+ * HR manager can only ever see their own employer's documents.
+ */
+export function CompanyDocuments() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [employerId, setEmployerId] = useState<string | null>(null);
+  const [employerName, setEmployerName] = useState<string>('');
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const profile = await authService.getProfile();
+        if (!active) return;
+        if (profile.hr_profile?.employer?.id) {
+          setEmployerId(profile.hr_profile.employer.id);
+          setEmployerName(profile.hr_profile.employer.name || '');
+        } else {
+          setError('Your account is not linked to a company yet. Please contact 254 Capital.');
+        }
+      } catch (err: any) {
+        if (active) setError(err.message || 'Failed to load your company information');
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-[#008080]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-2">
+          <FileText className="h-6 w-6 text-[#008080]" />
+          Company Documents
+        </h1>
+        <p className="text-slate-500 mt-1">
+          {employerName ? `Documents for ${employerName}` : 'Your company documents'}
+        </p>
+      </div>
+
+      {error ? (
+        <Card>
+          <div className="flex items-center gap-2 p-4 text-amber-700">
+            <AlertCircle className="h-5 w-5 flex-shrink-0" />
+            {error}
+          </div>
+        </Card>
+      ) : (
+        employerId && (
+          <Card>
+            <EmployerDocuments employerId={employerId} />
+          </Card>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/services/salary-checkoff/api.ts
+++ b/src/services/salary-checkoff/api.ts
@@ -62,6 +62,8 @@ export const API_ENDPOINTS = {
     DETAIL: (id: string) => `${API_BASE_URL}/api/v1/documents/${id}/`,
     APPLICATION_DOCUMENTS: (applicationId: string) =>
       `${API_BASE_URL}/api/v1/documents/application/${applicationId}/`,
+    EMPLOYER_DOCUMENTS: (employerId: string) =>
+      `${API_BASE_URL}/api/v1/documents/employer/${employerId}/`,
   },
 
   // Notification endpoints

--- a/src/services/salary-checkoff/document.service.ts
+++ b/src/services/salary-checkoff/document.service.ts
@@ -203,6 +203,39 @@ export const documentService = {
   },
 
   /**
+   * List employer-level documents (e.g. check-off agreements).
+   * Accessible to admins (any employer) and HR managers (their own employer).
+   */
+  listEmployerDocuments: async (employerId: string): Promise<Document[]> => {
+    const token = tokenManager.getAccessToken();
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(
+      API_ENDPOINTS.DOCUMENTS.EMPLOYER_DOCUMENTS(employerId),
+      {
+        method: 'GET',
+        headers,
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw {
+        message: errorData.detail || errorData.message || 'Request failed',
+        status: response.status,
+        data: errorData,
+      };
+    }
+
+    return await response.json();
+  },
+
+  /**
    * Fetch a document's file as a Blob.
    *
    * Resolves the file URL from the detail endpoint (which always returns it),

--- a/src/services/salary-checkoff/loan.service.ts
+++ b/src/services/salary-checkoff/loan.service.ts
@@ -2,7 +2,14 @@
  * Loan Service for Salary Check-Off System
  */
 
-import { apiRequest, API_ENDPOINTS } from './api';
+import { apiRequest, API_ENDPOINTS, tokenManager } from './api';
+
+/** Supporting documents submitted together with a loan application. */
+export interface LoanDocumentFiles {
+  national_id_front?: File;
+  national_id_back?: File;
+  payslips?: File[];
+}
 
 export interface LoanApplication {
   id: string;
@@ -274,15 +281,50 @@ export const loanService = {
    * Create new loan application
    */
   createApplication: async (
-    data: CreateLoanRequest
+    data: CreateLoanRequest,
+    files: LoanDocumentFiles
   ): Promise<LoanApplicationDetail> => {
-    return apiRequest<LoanApplicationDetail>(
-      API_ENDPOINTS.LOANS.APPLICATIONS,
-      {
-        method: 'POST',
-        body: JSON.stringify(data),
+    // The application and its required documents are submitted together as one
+    // multipart request. The backend creates them atomically — if a document is
+    // missing or fails, the application is not created.
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        formData.append(key, String(value));
       }
-    );
+    });
+    if (files.national_id_front) {
+      formData.append('national_id_front', files.national_id_front);
+    }
+    if (files.national_id_back) {
+      formData.append('national_id_back', files.national_id_back);
+    }
+    (files.payslips || []).slice(0, 3).forEach((file, index) => {
+      formData.append(`payslip_${index + 1}`, file);
+    });
+
+    const token = tokenManager.getAccessToken();
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(API_ENDPOINTS.LOANS.APPLICATIONS, {
+      method: 'POST',
+      headers,
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw {
+        message: errorData.detail || errorData.message || 'Failed to submit application',
+        status: response.status,
+        data: errorData,
+      };
+    }
+
+    return await response.json();
   },
 
   /**


### PR DESCRIPTION
Submit required documents (ID front/back, payslips) together with the loan application so they are stored and linked. Previously the ID/payslip uploads were sent with no application_id and rejected by the backend, so applications ended up with no documents. Documents are now mandatory before submission.

Also surface employer-level documents (e.g. check-off agreements):
- Add reusable EmployerDocuments component with inline preview/download.
- Admins view any employer's documents from the Employers screen; HR managers view their own company's via a new Company Documents page (scoped by backend).
- Add documentService.listEmployerDocuments + EMPLOYER_DOCUMENTS endpoint.